### PR TITLE
Add onRedirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ A decorator on top of `fetch` that caches the DNS query of the `hostname` of the
 const fetch = require('fetch-cached-dns')(require('node-fetch'))
 ```
 
+Since this implementation is implementing redirects we are providing an `onRedirect` extra 
+option to the `fetch` call that allows one to customize the redirect options just before it
+happens.
+
 *NOTE: if the fetch implementation is not supplied, it will attempt to use peerDep `node-fetch`*

--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ function setup(fetch) {
 
       const location = res.headers.get('Location')
       redirectOpts.headers.delete('Host')
+
+      if (opts.onRedirect) {
+        opts.onRedirect(redirectOpts)
+      }
+
       return fetchCachedDns(location, redirectOpts)
     } else {
       return res


### PR DESCRIPTION
This branch adds a `onRedirect` custom option to `fetch` that is called just before a redirection happens so we can customize the redirection options 

The reasoning behind this change comes from [@zeit/fetch](https://github.com/zeit/fetch). Turns out that when there is a redirection from `http` to `https` the responsibility of switching the `agent` should be managed there but there is no way to do so since the redirection happens at `@zeit/fetch-cached-dns` level.