### PR TITLE
Add res object to onRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ const fetch = require('fetch-cached-dns')(require('node-fetch'))
 ```
 
 Since this implementation is implementing redirects we are providing an `onRedirect` extra 
-option to the `fetch` call that allows one to customize the redirect options just before it
-happens.
+option to the `fetch` call that gets called with the response object and the options that
+will be used for the next request. This allows to access the request from outside and to
+modify the options.
 
 *NOTE: if the fetch implementation is not supplied, it will attempt to use peerDep `node-fetch`*

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function setup(fetch) {
       redirectOpts.headers.delete('Host')
 
       if (opts.onRedirect) {
-        opts.onRedirect(redirectOpts)
+        opts.onRedirect(res, redirectOpts)
       }
 
       return fetchCachedDns(location, redirectOpts)

--- a/test.js
+++ b/test.js
@@ -107,15 +107,17 @@ test('works with `onRedirect` option to customize opts', async () => {
   const { port } = server.address()
 
   const options = {
-    onRedirect: jest.fn(opts => {
+    onRedirect: jest.fn((res, opts) => {
       opts.randomOption = true
     })
   }
 
   await cachedDNSFetch(`http://localtest.me:${port}`, options)
   expect(options.onRedirect.mock.calls.length).toBe(1)
-  expect(options.onRedirect.mock.calls[0][0].headers).toBeDefined()
-  expect(options.onRedirect.mock.calls[0][0].randomOption).toBe(true)
+  const [res, opts] = options.onRedirect.mock.calls[0]
+  expect(res.status).toEqual(302)
+  expect(opts.headers).toBeDefined()
+  expect(opts.randomOption).toBe(true)
 
   server.close()
 })


### PR DESCRIPTION
Since usually we will need to access the `Location` header and maybe the response, this PR is adding it as the first parameter for `onRetry` option, leaving the options that will be used for the next request as the second argument.