### PR TITLE
Propagate timeout to manual redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function setup(fetch) {
   const { Headers } = fetch
 
   async function fetchCachedDns(url, opts) {
+    const started = Date.now()
     const parsed = parse(url)
     const ip = isIP(parsed.hostname)
     if (ip === 0) {
@@ -29,6 +30,11 @@ function setup(fetch) {
     if (isRedirect(res.status)) {
       const redirectOpts = Object.assign({}, opts)
       redirectOpts.headers = new Headers(opts.headers)
+
+      if (redirectOpts.timeout) {
+        const nextTimeout = redirectOpts.timeout - (Date.now() - started)
+        redirectOpts.timeout = nextTimeout > 0 ? nextTimeout : 0
+      }
 
       // per fetch spec, for POST request with 301/302 response, or any request with 303 response, use GET when following redirect
       if (

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function setup(fetch) {
   const { Headers } = fetch
 
   async function fetchCachedDns(url, opts) {
-    const started = Date.now()
+    const startedAt = Date.now()
     const parsed = parse(url)
     const ip = isIP(parsed.hostname)
     if (ip === 0) {
@@ -32,7 +32,7 @@ function setup(fetch) {
       redirectOpts.headers = new Headers(opts.headers)
 
       if (redirectOpts.timeout) {
-        const nextTimeout = redirectOpts.timeout - (Date.now() - started)
+        const nextTimeout = redirectOpts.timeout - (Date.now() - startedAt)
         redirectOpts.timeout = nextTimeout > 0 ? nextTimeout : 0
       }
 


### PR DESCRIPTION
We had an issue with a fetch where the server was generating an infinite number of redirects. In this case even having a timeout set, the fetch where never throwing but stuck in the loop. With this PR we are checking if there is a timeout in the options for a fetch and in a positive case we track the time spent for the fetch and modify the timeout according to it when making the recursion.